### PR TITLE
Faster performance in todos

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Meant to be shipped with each monorepo (main.py is standalone) for better toolin
 Here `nodeServer`, `todoClient`, `goServer` are the names of repos inside the monorepo. The goal of this file to let monoinit know all the common commands all these projects has. For instance, when `run` command is ran at the root of the monorepo, monoinit searches for `run` in all of the repos, executes them together and aggregates the outputs and shows them all together. There's no point of running the command when the shell is inside one of the repo folders.
 
 ## Screenshot of the shell
-![image](https://user-images.githubusercontent.com/63333626/157265006-e73b79ff-cc54-47ac-9432-1bd1398f8199.png)
+![image](https://user-images.githubusercontent.com/83999665/158515493-0278ffd6-45c2-47f4-9073-184cc68d99b5.png)
 
 
 ### Team

--- a/example/py1/main.py
+++ b/example/py1/main.py
@@ -1,1 +1,2 @@
 print("hello world")
+#TODO: TEST

--- a/example/py2/main.py
+++ b/example/py2/main.py
@@ -1,1 +1,2 @@
 print("hello world")
+#   todo: TEST

--- a/main.py
+++ b/main.py
@@ -55,23 +55,12 @@ def todos(folder: str) -> str:
 
     files, c, n = {}, os.getcwd(), '\n'
     for i in getFiles(folder):
-        with open(i, 'r') as f:
-            for lineNo, item in enumerate(f.readlines()):
-                if len([k for k in ["#todo", "//todo"] if k in item.lower().replace(" ", "")]) == 0:
-                    continue
-                
-                
-                if i not in list(files.keys()):
-                    files[i] = [f"{lineNo+1}. | {item.strip(n)}"]
-                else:
-                    files[i].append(f"{lineNo+1}. | {item.strip(n)}")
-    fancyReturn = ""
-    n = "\n\t"
-    
-    for i in list(files.keys()):
-        fancyReturn += f"\nPath: {i[len(c)+1:]}\n\t{n.join(files[i])}\n"
+        cmd = '#[[:blank:]]\+todo' if i.endswith('.py') else '//[[:blank:]]\+todo'
+        if (x := subprocess.getoutput(
+            f"cat {i} | grep -in -e \"{cmd}\" -e \"{'#todo' if i.endswith('.py') else '//todo'}\""
+        )) == "": continue
 
-    return fancyReturn[:-1]
+        print(f"FILE: {i[len(PARENT_DIR)+1:]}\n\t{x}")
 
 # === SHELL === #
 def shell(command: str) -> typing.Any:


### PR DESCRIPTION
## Description of the change
- `todos` will now run the GNU `grep` command to check for todos making it faster.
- examples have a comment with a todo for testing purposes.


## Checklist

**I agree to the following :-**

* [x]   Added description of the change
* [x]   I've read the [code of conduct](../CODE_OF_CONDUCT.md)
* [x]   Search previous suggestions before making a new PR, as yours may be a duplicate.
* [x]  I acknowledge that all my contributions will be made under the project's license.
