### PR TITLE
Running multiple commands from workflow.json

### DIFF
--- a/example/workflow.json
+++ b/example/workflow.json
@@ -1,10 +1,11 @@
 {
-    "py1": {
+    "client": {
         "folder": "py1",
         "run": "python3 main.py",
-        "test": "npm run test"
+        "test": "npm run test",
+		"echostuff": "echo 'hi!'"
     },
-    "py2": {
+    "node": {
         "folder": "py2",
         "install": "pip install --upgrade -r requirements.txt",
         "run": "python3 main.py",

--- a/main.py
+++ b/main.py
@@ -10,7 +10,6 @@ if os.name == "nt":
 import typing, argparse, readline, json, subprocess, traceback
 from cmd import Cmd
 
-
 # === COMPLETER === #
 class Completer(object):
     def __init__(self, options):
@@ -207,25 +206,32 @@ def shell(command: str) -> typing.Any:
             json.dump(WORKFLOW, f, indent=4)
 
     # === TO EXIT === #     
-    elif command.lower().startswith("exit") :
+    elif command.lower().startswith("exit"):
         exit_ = True
 
     else:
-        repos = []
+        commands = {}
         for i in WORKFLOW:
             if command in list(WORKFLOW[i].keys())[1:]:
-                repos.append(i)
+                commands[WORKFLOW[i]["folder"]] = WORKFLOW[i][command]
 
         if os.getcwd() != PARENT_DIR:
             os.system(command)
             return
 
-        if len(repos) > 0:
-            for i in repos:
-                print(f"==> Switching to {WORKFLOW[i]['folder']}")
-                os.chdir(WORKFLOW[i]["folder"])
-                os.system(WORKFLOW[i][command])
-                os.chdir(PARENT_DIR)
+        elif len(commands) == 1:
+            os.chdir(list(commands.keys())[0])
+            os.system(commands[list(commands.keys())[0]])
+            os.chdir(PARENT_DIR)
+
+        elif len(commands) > 0:
+            keys = list(commands.keys())
+            for index, item in enumerate(commands.values()):
+                commands[keys[index]] = \
+                    f"{'tmux new-session' if index == 0 else 'new-window'} " \
+                    f"\'cd {keys[index]} && {item} && sh -c read\'\\;"
+            os.system(" ".join(commands.values()))
+        
         else:
             os.system(command)
 


### PR DESCRIPTION
## Description of the change
- NEW EXTERNAL DEPENDENCY: tmux
- If there are multiple repos with the same command in workflow, the script will open a tmux session with multiple tabs to run the commands in parellel.
  Use `ctrl + b p` and `ctrl + b n` to navigate the tabs.

## Checklist

**I agree to the following :-**

* [x]   Added description of the change
* [x]   I've read the [code of conduct](../CODE_OF_CONDUCT.md)
* [x]   Search previous suggestions before making a new PR, as yours may be a duplicate.
* [x]   I acknowledge that all my contributions will be made under the project's license.
