### PR TITLE
Arguments in custom commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,13 @@ Meant to be shipped with each monorepo (This script is standalone) for better to
 
 Here `socket` and `client` are the names of repos inside the monorepo. The goal of this file to let monoinit know all the common commands these projects have. For instance, when `run` command is ran at the root of the monorepo, monoinit searches for `run` in all of the repos, executes them together and aggregates the outputs and shows them all together. There's no point of running the command when the shell is inside one of the repo folders.
 
+You can also specify the repo to run the command in when running a custom command. For example:
+```bash
+run client # the script will run the corresponding command only in the client repo
+```
+
 ## Commands
-MonoInit is like the default `/bin/sh` except it has some more commands to help you with managing your /monorepo.
+MonoInit is like the default `/bin/sh` except it has some more commands to help you with managing your monorepo.
 
 - `init`
     This command will initialise an empty repo. 

--- a/example/workflow.json
+++ b/example/workflow.json
@@ -2,13 +2,12 @@
     "client": {
         "folder": "py1",
         "run": "python3 main.py",
-        "test": "npm run test",
+        "test": "python3 tests.py",
 		"echostuff": "echo 'hi!'"
     },
     "node": {
         "folder": "py2",
         "install": "pip install --upgrade -r requirements.txt",
-        "run": "python3 main.py",
-        "build": "python3 -m build"
+        "run": "python3 main.py"
     }
 }


### PR DESCRIPTION
## Description of the change
- You can now add arguments to the custom commands to specify the repo to run it in (example: `run client`)

## Checklist

**I agree to the following :-**

* [x]   Added description of the change
* [x]   I've read the [code of conduct](../CODE_OF_CONDUCT.md)
* [x]   Search previous suggestions before making a new PR, as yours may be a duplicate.
* [x]   I acknowledge that all my contributions will be made under the project's license.
