### PR TITLE
Fix issue #32

### DIFF
--- a/example/workflow.json
+++ b/example/workflow.json
@@ -4,12 +4,12 @@
         "run": "python3 main.py",
         "test": "python3 tests.py",
 		"echostuff": "echo 'hi!'",
-        "hook": "echo testClient"
+        "hook": "pwd"
     },
     "node": {
         "folder": "py2",
         "install": "pip install --upgrade -r requirements.txt",
         "run": "python3 main.py",
-        "hook": "echo node"
+        "hook": "pwd"
     }
 }

--- a/main.py
+++ b/main.py
@@ -118,10 +118,18 @@ def shell(command: str) -> typing.Any:
                 "blue)<%an>%Creset' --abbrev-commit")
 
         elif command.startswith("git add"):
+            if command == "git add":
+                print("Nothing specified, nothing added.\nMaybe run 'git add .'?")
+                return
             cmds, cmd, bslash, TERM = [], "", "\; ", os.environ["TERM"]
             for i in WORKFLOW:
                 if "hook" in list(WORKFLOW[i].keys()):
-                    cmds.append(f"{WORKFLOW[i]['hook']} ; read ")
+                    cmds.append(
+                        f"cd {os.path.join(PARENT_DIR, WORKFLOW[i]['folder'])} && " 
+                        f"{WORKFLOW[i]['hook']} && " 
+                        f"cd {PARENT_DIR} ; read "
+                    )
+            
             for index, item in enumerate(cmds):
                 if TERM == "screen" and index == 0:
                     _ = "tmux new-window"


### PR DESCRIPTION
## Description of the change
- Hooks now run in their respective directory ( #32 )
- Running `git add` without specifying a directory will not work as shown in the below screenshot

## Screenshots
![image](https://user-images.githubusercontent.com/83999665/168421679-f907d29f-fb6e-4546-b8e2-3e117da95922.png)
Hooks after running `git add .` ( example hooks run the command `pwd` )
![image](https://user-images.githubusercontent.com/83999665/168421745-e1ee5bd7-2817-4545-8158-bd37009ee3be.png)

## Checklist

**I agree to the following :-**

* [x]   Added description of the change
* [x]   I've read the [code of conduct](../CODE_OF_CONDUCT.md)
* [x]   Search previous suggestions before making a new PR, as yours may be a duplicate.
* [x]   I acknowledge that all my contributions will be made under the project's license.
