### PR TITLE
hooks: an array for commands (#38)

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,18 +33,22 @@ Expects a file called `workflow.json` at the root of monorepo. This file has con
     "socket": {
         "folder": "py1",
         "run": "python3 main.py",
-        "test": "python3 test.py"
+        "test": "python3 test.py",
+        "hooks": [
+          "lint",
+          "format"
+        ]
     },
     "client": {
         "folder": "py2",
         "install": "pip install --upgrade -r requirements.txt",
         "run": "python3 main.py"
-        "hook": "lint"
+        "hooks": "lint"
     }
 }
 ```
 
-Here `socket` and `client` are the names of repos inside the monorepo. The goal of this file to let monoinit know all the common commands these projects have. For instance, when `run` command is ran at the root of the monorepo, monoinit searches for `run` in all of the repos, executes them together and aggregates the outputs and shows them all together. There's no point of running the command when the shell is inside one of the repo folders. The `hook` field is optional and is not a command, it is executed each time when you run `git add` anywhere in the project.
+Here `socket` and `client` are the names of repos inside the monorepo. The goal of this file to let monoinit know all the common commands these projects have. For instance, when `run` command is ran at the root of the monorepo, monoinit searches for `run` in all of the repos, executes them together and aggregates the outputs and shows them all together. There's no point of running the command when the shell is inside one of the repo folders. The `hooks` field is optional and is executed when you run `git add` anywhere in the project.
 
 ## Commands
 
@@ -76,7 +80,7 @@ Apart from these commands, you can use all the other commands on your machine.
 
 ![image](https://user-images.githubusercontent.com/83999665/159155974-a5bf031b-3948-4759-93e4-2b5f1a32d144.png)
 
-- hooks: the `hook` field in the workflow file will run the specified command for the particular repo each time the changes are added to the staging area via `git add`, this is useful for running linters, formatters or some custom checks
+- hooks: the `hooks` field in the workflow file will run the specified command for the particular repo each time the changes are added to the staging area via `git add`, this is useful for running linters, formatters or some custom checks
 
 ---
 

--- a/example/workflow.json
+++ b/example/workflow.json
@@ -4,12 +4,12 @@
         "run": "python3 main.py",
         "test": "python3 tests.py",
 		"echostuff": "echo 'hi!'",
-        "hook": "pwd"
+        "hooks": "pwd"
     },
     "node": {
         "folder": "py2",
         "install": "pip install --upgrade -r requirements.txt",
         "run": "python3 main.py",
-        "hook": "pwd"
+        "hooks": ["pwd", "ls", "echo 'test hooks'"]
     }
 }

--- a/main.py
+++ b/main.py
@@ -117,13 +117,13 @@ def shell(command: str) -> typing.Any:
                 return
             cmds, cmd, bslash, TERM = [], "", "\; ", os.environ["TERM"]
             for i in WORKFLOW:
-                if "hook" in list(WORKFLOW[i].keys()):
-                    cmds.append(
-                        f"cd {os.path.join(PARENT_DIR, WORKFLOW[i]['folder'])} && " 
-                        f"{WORKFLOW[i]['hook']} && " 
-                        f"cd {PARENT_DIR} ; read "
-                    )
-            
+                if "hooks" not in list(WORKFLOW[i].keys()): continue
+                cmds.append(
+                    f"cd {os.path.join(PARENT_DIR, WORKFLOW[i]['folder'])} && " 
+                    f"{' && '.join(WORKFLOW[i]['hooks']) if type(WORKFLOW[i]['hooks']) == list else WORKFLOW[i]['hooks']} && " 
+                    f"read "
+                )
+
             for index, item in enumerate(cmds):
                 if TERM == "screen" and index == 0:
                     _ = "tmux new-window"
@@ -133,7 +133,7 @@ def shell(command: str) -> typing.Any:
                     _ = "split-window"
                 elif index != 0:
                     _ = "new-window"
-                cmd += f"{_} \'{item}\' {bslash if index != len(cmds)-1 else '&& '}"
+                cmd += f"{_} \"{item}\" {bslash if index != len(cmds)-1 else '&& '}"
             cmd += command
 
             os.system(cmd)


### PR DESCRIPTION
* hooks: an array for commands

An array can be supplied for hooks in workflow.json to run multiple commands as hooks

* docs: update README.md

* hooks: change `hook` to `hooks` in workflow

To add hooks in workflow.json, the key `hooks` is now needed instead of `hook`

## Description of the change

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

<!-- If it fixes an issue, please add Closes #issue_no below with its respective issue number -->

## Screenshots

<!-- Please add screenshots if applicable. Otherwise, remove this section -->

## Checklist

**I agree to the following :-**

* [ ]   Added description of the change
* [ ]   I've read the [code of conduct](../CODE_OF_CONDUCT.md)
* [ ]   Search previous suggestions before making a new PR, as yours may be a duplicate.
* [ ]   I acknowledge that all my contributions will be made under the project's license.

Notes (**optional**): <!-- Please add a one-line description for developers or pull request viewers -->